### PR TITLE
Update aws-sdk dependency to aws-sdk-s3

### DIFF
--- a/lib/s3_sign.rb
+++ b/lib/s3_sign.rb
@@ -23,7 +23,7 @@ module S3Sign
   protected
 
   def self.build_options(options)
-    { expires_in: options.fetch(:expires, SEVEN_DAYS) }.tap do |o|
+    { expires_in: options.fetch(:expires, SEVEN_DAYS).to_i }.tap do |o|
       attachment_filename = options[:attachment_filename]
 
       if attachment_filename

--- a/lib/s3_sign.rb
+++ b/lib/s3_sign.rb
@@ -1,6 +1,6 @@
 require "s3_sign/version"
 require "s3_sign/helper"
-require "aws"
+require "aws-sdk-s3"
 
 module S3Sign
   SEVEN_DAYS = 60 * 60 * 24 * 7
@@ -13,18 +13,17 @@ module S3Sign
   end
 
   def self.url(s3_url, options = {})
-    s3 = AWS::S3.new
-    bucket = s3.buckets[bucket_name]
-
+    s3 = Aws::S3::Resource.new
+    bucket = s3.bucket(bucket_name)
     path = path_from_s3_url(s3_url)
-
-    AWS::S3::S3Object.new(bucket, path).url_for(:read, build_options(options)).to_s
+    obj = bucket.object(path)
+    obj.presigned_url(:get, **build_options(options))
   end
 
   protected
 
   def self.build_options(options)
-    { expires: options.fetch(:expires, SEVEN_DAYS) }.tap do |o|
+    { expires_in: options.fetch(:expires, SEVEN_DAYS) }.tap do |o|
       attachment_filename = options[:attachment_filename]
 
       if attachment_filename

--- a/lib/s3_sign/helper.rb
+++ b/lib/s3_sign/helper.rb
@@ -1,3 +1,5 @@
+require "time"
+
 module S3Sign
   module Helper
     def self.included(base)

--- a/s3_sign.gemspec
+++ b/s3_sign.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "aws-sdk", "~> 1.36"
+  spec.add_dependency "aws-sdk-s3", "~> 1"
 
   spec.add_development_dependency "bundler", "~> 1.8"
   spec.add_development_dependency "rake", ">= 12.3.3"

--- a/spec/s3_sign_spec.rb
+++ b/spec/s3_sign_spec.rb
@@ -2,10 +2,7 @@ require "spec_helper"
 
 describe S3Sign, '.url' do
   before do
-    AWS.config(
-      :access_key_id     => "spec_access_key_id",
-      :secret_access_key => "spec_secret_access_key"
-    )
+    Aws.config.update(credentials: Aws::Credentials.new("spec_access_key_id", "spec_secret_access_key"))
 
     S3Sign.bucket_name = "spec_bucket"
   end
@@ -23,7 +20,7 @@ describe S3Sign, '.url' do
 
     url = "https://s3.amazonaws.com/#{bucket}/accounts/2/products/photo.jpg"
     signed = S3Sign.url(url)
-    expect(signed).to match(%r{^https://s3.amazonaws.com/#{bucket}/accounts/2/products/photo.jpg\?AWSAccessKeyId=#{access_key}&Expires=\d+&Signature=.+%3D$})
+    expect(signed).to match(%r{^https://s3.amazonaws.com/#{bucket}/accounts/2/products/photo.jpg\?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=#{access_key}%2F\d+%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=\w+&X-Amz-Expires=\d+&X-Amz-SignedHeaders=host&X-Amz-Signature=\w+$})
   end
 
   it "can receive an optional expires value" do
@@ -32,8 +29,7 @@ describe S3Sign, '.url' do
 
     url = "https://s3.amazonaws.com/#{bucket}/accounts/2/products/photo.jpg"
     signed = S3Sign.url(url, expires: 42)
-    expires_timestamp = (Time.now + 42).to_i
-    expect(signed).to match(%r{^https://s3.amazonaws.com/#{bucket}/accounts/2/products/photo.jpg\?AWSAccessKeyId=#{access_key}&Expires=#{expires_timestamp}&Signature=.+%3D$})
+    expect(signed).to match(%r{^https://s3.amazonaws.com/#{bucket}/accounts/2/products/photo.jpg\?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=#{access_key}%2F\d+%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=\w+&X-Amz-Expires=42&X-Amz-SignedHeaders=host&X-Amz-Signature=\w+$})
   end
 
   it "will add response_content_type for the given attachment_filename if present" do


### PR DESCRIPTION
The signed urls have a different format, but local testing generated valid urls.