### PR TITLE
chore: update keys

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           gem build *.gemspec
           gem push --KEY github --host https://rubygems.pkg.github.com/${OWNER} *.gem
         env:
-          GEM_HOST_API_KEY: "Bearer ${{secrets.GITHUB_TOKEN}}"
+          GEM_HOST_API_KEY: "Bearer ${{secrets.GHA_WRITE_TOKEN}}"
           OWNER: ${{ github.repository_owner }}
         if: ${{ steps.release.outputs.release_created }}
       - name: Publish to RubyGems


### PR DESCRIPTION
I'm trying to allow our static and test to run on pushes to main, but they do not get triggered with the `GITHUB_TOKEN` when using release-please, so I'm trying to use a different key.